### PR TITLE
Switch to new endpoint

### DIFF
--- a/app/utils/GitHub.scala
+++ b/app/utils/GitHub.scala
@@ -126,7 +126,7 @@ class GitHub @Inject() (configuration: Configuration, ws: WSClient, messagesApi:
   }
 
   def installationAccessTokens(installationId: Int): Future[JsValue] = {
-    val (ws, claim) = jwtWs(s"installations/$installationId/access_tokens")
+    val (ws, claim) = jwtWs(s"app/installations/$installationId/access_tokens")
 
     ws.post(claim.toJsValue()).flatMap(created)
   }


### PR DESCRIPTION
GitHub is deprecating this old endpoint, and switching it to have `app/` as it's base. Quick fix to get out of hot water!

```
Hi @sonatype-nexus-community App Manager,

On September 24th, 2020 at 02:17 (PDT) the application "sonatypecla" owned by your organization issued a request using the deprecated endpoint for creating access tokens. GitHub has deprecated this undocumented endpoint, its replacement which accepts the same arguments is available now.

This endpoint will be removed on October 1st, 2020.

Please visit https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint for more information about suggested changes, brownouts, and removal dates.
```